### PR TITLE
Feature: new key bindings to add doc URL in comment above resource or data block

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ browser tab with the resource or data documentation page.
 
 Type `C-c C-d C-c` to kill the URL (i.e. copy it to the clipboard) for the documentation page rather than directly open it in the browser.
 
+You can also type `C-c C-d C-r` to insert a comment containing a link to
+this documentation right above the resource or data block.
+
 ## Customize Variables
 
 #### `terraform-indent-level`(Default: `2`)

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -286,6 +286,14 @@
     (kill-new url)
     (message "Copied URL: %s" url)))
 
+(defun terraform-insert-doc-in-comment ()
+  "Insert a comment containing an URL documenting the resource at point."
+  (interactive)
+  (let ((doc-url (terraform--resource-url-at-point)))
+    (unless (looking-at-p "^resource\\|^data")
+      (re-search-backward "^resource\\|^data" nil t))
+    (insert (format "# %s\n" doc-url))))
+
 (defun terraform--outline-level ()
   "Return the depth to which a statement is nested in the outline.
 
@@ -325,6 +333,7 @@ If the point is not at the heading, call
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-d C-w") #'terraform-open-doc)
     (define-key map (kbd "C-c C-d C-c") #'terraform-kill-doc-url)
+    (define-key map (kbd "C-c C-d C-r") #'terraform-insert-doc-in-comment)
     (define-key map (kbd "C-c C-f") #'outline-toggle-children)
     map))
 

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -290,9 +290,10 @@
   "Insert a comment containing an URL documenting the resource at point."
   (interactive)
   (let ((doc-url (terraform--resource-url-at-point)))
-    (unless (looking-at-p "^resource\\|^data")
-      (re-search-backward "^resource\\|^data" nil t))
-    (insert (format "# %s\n" doc-url))))
+    (save-excursion
+      (unless (looking-at-p "^resource\\|^data")
+        (re-search-backward "^resource\\|^data" nil t))
+      (insert (format "# %s\n" doc-url)))))
 
 (defun terraform--outline-level ()
   "Return the depth to which a statement is nested in the outline.

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -126,6 +126,21 @@ data \"aws_subnets\" \"example\" {
     (cl-letf (((symbol-function 'terraform--get-resource-provider-namespace) (lambda (prov) "hashicorp")))
       (should (equal (terraform--resource-url-at-point) "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets")))))
 
+(ert-deftest command--add-comment-doc--at-data-resource-def-line ()
+  (with-terraform-temp-buffer
+    "
+data \"aws_subnets\" \"example\" {
+  filter {
+    name   = \"vpc-id\"
+    values = [var.vpc_id]
+  }
+}
+"
+    (forward-cursor-on "filter")
+    (cl-letf (((symbol-function 'terraform--get-resource-provider-namespace) (lambda (prov) "hashicorp")))
+      (terraform-insert-doc-in-comment)
+      (should (equal (search-backward "# https://registry") 2)))))
+
 (ert-deftest command--open-doc--in-body ()
   (with-terraform-temp-buffer
     "


### PR DESCRIPTION
In a typical team, not all people can directly access resource documentation using only the resource declaration.

With this patch, terraform-mode users can add a link in a comment pointing to the resource documentation by typing   `C-c C-d C-r`.

@vspinu Is this binding fine with you ?

All the best