### PR TITLE
Added support for .tofu suffix for OpenTofu

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -404,7 +404,7 @@ If the point is not at the heading, call
   (imenu-add-to-menubar "Terraform"))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.tf\\(vars\\)?\\'" . terraform-mode))
+(add-to-list 'auto-mode-alist '(".\\(tf\\(vars\\)?\\|tofu\\)'". terraform-mode))
 
 (provide 'terraform-mode)
 


### PR DESCRIPTION
With the release of OpenTofu 1.8, support for files with .tofu suffix was added. See: https://github.com/opentofu/opentofu/pull/1738

This change enables terraform-mode for .tofu files, "out of the box".