### PR TITLE
Really add .tofu suffix

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -404,7 +404,7 @@ If the point is not at the heading, call
   (imenu-add-to-menubar "Terraform"))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '(".\\(tf\\(vars\\)?\\|tofu\\)'". terraform-mode))
+(add-to-list 'auto-mode-alist '("\\.t\\(f\\(vars\\)?\\|ofu\\)\\'" . terraform-mode))
 
 (provide 'terraform-mode)
 


### PR DESCRIPTION
With the previous change https://github.com/hcl-emacs/terraform-mode/pull/71 the leading dot was not escaped and this broke the terraform-mode (since it wouldn't automatically autoload it for .tf(vars)? files, but it also wouldn't work for .tofu files either).

So this is a bug fix.